### PR TITLE
Added homepage/congress or parliament page links to congress.js and parliament.js

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,7 @@ function App()
     <div className="App">
       <Router>
         <Routes>
-          <Route path="/API-app" element={<Homepage />} /> 
+          <Route path="/homepage" element={<Homepage />} /> 
           <Route path="/congress" element={<Congress />} />
           <Route path="/parliament" element={<Parliament />} />
         </Routes>

--- a/src/Congress.js
+++ b/src/Congress.js
@@ -227,7 +227,7 @@ function Congress()
       <br></br>
       <p>I want to</p>
       <div className="linkText">
-        <Link to="/parliament">explore the UK parliament.</Link>
+        <Link to="/parliament">explore the UK parliament</Link>
         <Link to="/homepage">go back to the homepage</Link>
       </div>
 

--- a/src/Congress.js
+++ b/src/Congress.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 
 function Congress() 
 {
@@ -220,6 +221,15 @@ function Congress()
           
         </div>
       )}
+      <br></br>
+
+      <br></br>
+      <br></br>
+      <p>I want to</p>
+      <div className="linkText">
+        <Link to="/parliament">explore the UK parliament.</Link>
+        <Link to="/homepage">go back to the homepage</Link>
+      </div>
 
       </div>
       </div>

--- a/src/Parliament.js
+++ b/src/Parliament.js
@@ -1,4 +1,6 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+
 
 const Parliament = () => {
   // State hooks for member data
@@ -174,6 +176,18 @@ const resetMemberInfo = () => {
     </ul>
   </div>
 )}
+<br></br>
+
+<br></br>
+<br></br>
+<div style={{ textAlign: 'center' }}>
+<p>I want to</p>
+</div>
+
+<div className="linkText">
+  <Link to="/congress">explore the US congress</Link>
+  <Link to="/homepage">go back to the homepage</Link>
+</div>
 
     </div>
   );


### PR DESCRIPTION
Our 3 paths managed by a router are
<img width="418" alt="Paths" src="https://github.com/DavidA123777/API-APP-V2/assets/90419249/af3865ca-2e2b-4c12-baf5-76d1d9321d26">
I just made the parliament and congress pages more accessible as now you can traverse through all three pages from either page rather than having to click the back arrow:

https://github.com/DavidA123777/API-APP-V2/assets/90419249/85cf7c81-d5e9-4689-802a-7604aaccdc3e

